### PR TITLE
fix: don't configure source/execution data for projects with no dirs

### DIFF
--- a/src/main/java/com/jrmcdonald/common/baseline/core/jacoco/CodeCoverageReportTask.java
+++ b/src/main/java/com/jrmcdonald/common/baseline/core/jacoco/CodeCoverageReportTask.java
@@ -5,6 +5,9 @@ import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.testing.jacoco.plugins.JacocoPlugin;
 import org.gradle.testing.jacoco.tasks.JacocoReport;
 
+import java.io.File;
+import java.util.Objects;
+
 @SuppressWarnings("java:S110")
 public class CodeCoverageReportTask extends JacocoReport {
 
@@ -28,10 +31,15 @@ public class CodeCoverageReportTask extends JacocoReport {
     private void configureSourceSetsAndExecutionData(Project project) {
         project.getTasks().matching(JacocoUtils::hasJacocoTaskExtension).configureEach(task -> {
             var javaPluginConvention = project.getConvention().getPlugin(JavaPluginConvention.class);
-            var main = javaPluginConvention.getSourceSets().findByName("main");
+            var main = Objects.requireNonNull(javaPluginConvention.getSourceSets().findByName("main"));
 
-            sourceSets(main);
-            executionData(task);
+            var sourceExists = main.getAllJava().getSourceDirectories().getFiles().stream().allMatch(File::exists);
+
+            // this accounts for projects with intermediate, empty, sub-projects
+            if (sourceExists) {
+                sourceSets(main);
+                executionData(task);
+            }
         });
     }
 

--- a/src/test/java/com/jrmcdonald/common/baseline/core/jacoco/CodeCoverageReportTaskTest.java
+++ b/src/test/java/com/jrmcdonald/common/baseline/core/jacoco/CodeCoverageReportTaskTest.java
@@ -7,25 +7,39 @@ import org.gradle.testing.jacoco.plugins.JacocoPlugin;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class CodeCoverageReportTaskTest {
 
+    @TempDir
+    public File projectDir;
+
     private Project rootProject;
 
     @BeforeEach
     void beforeEach() {
-        rootProject = ProjectBuilder.builder().withName("rootProject").build();
+        rootProject = ProjectBuilder.builder().withName("rootProject").withProjectDir(projectDir).build();
         rootProject.getTasks().register(CodeCoverageReportTask.NAME, CodeCoverageReportTask.class);
 
-        var subProject = ProjectBuilder.builder().withName("subProject").withParent(rootProject).build();
+        var intermediateProject = ProjectBuilder.builder().withName("intermediateProject").withParent(rootProject).build();
+        intermediateProject.getPlugins().apply(JavaPlugin.class);
+        intermediateProject.getPlugins().apply(JacocoPlugin.class);
+
+        var subProject = ProjectBuilder.builder().withName("subProject").withParent(intermediateProject).build();
         subProject.getPlugins().apply(JavaPlugin.class);
         subProject.getPlugins().apply(JacocoPlugin.class);
+
+        var javaSrc = projectDir.toPath().resolve("intermediateProject/subProject/src/main/java");
+        assertThat(javaSrc.toFile().mkdirs()).isTrue();
 
         // work around task configuration avoidance by calling eagerly loading the jacocoTestReport task
         // https://docs.gradle.org/current/userguide/task_configuration_avoidance.html
         // this ensures that the source sets get configured in the unit test
+        intermediateProject.getTasks().getByName("jacocoTestReport");
         subProject.getTasks().getByName("jacocoTestReport");
     }
 
@@ -42,20 +56,38 @@ class CodeCoverageReportTaskTest {
     }
 
     @Test
-    @DisplayName("Should configure source sets")
-    void shouldConfigureSourceSets() {
+    @DisplayName("Should not configure source sets for intermediate project")
+    void shouldNotConfigureSourceSetsForIntermediateProject() {
         rootProject.getTasks().withType(CodeCoverageReportTask.class, task -> {
             var fileSystemLocations = task.getSourceDirectories().getElements().get();
-            assertThat(fileSystemLocations).anyMatch(fileSystemLocation -> fileSystemLocation.toString().contains("subProject/src/main/java"));
+            assertThat(fileSystemLocations).noneMatch(fileSystemLocation -> fileSystemLocation.toString().contains("intermediateProject/src/main/java"));
         });
     }
 
     @Test
-    @DisplayName("Should configure execution data")
-    void shouldConfigureExecutionData() {
+    @DisplayName("Should configure source sets for sub project")
+    void shouldConfigureSourceSetsForSubProject() {
+        rootProject.getTasks().withType(CodeCoverageReportTask.class, task -> {
+            var fileSystemLocations = task.getSourceDirectories().getElements().get();
+            assertThat(fileSystemLocations).anyMatch(fileSystemLocation -> fileSystemLocation.toString().contains("intermediateProject/subProject/src/main/java"));
+        });
+    }
+
+    @Test
+    @DisplayName("Should not configure execution data for intermediate project")
+    void shouldNotConfigureExecutionDataForIntermediateProject() {
         rootProject.getTasks().withType(CodeCoverageReportTask.class, task -> {
             var fileSystemLocations = task.getExecutionData().getElements().get();
-            assertThat(fileSystemLocations).anyMatch(fileSystemLocation -> fileSystemLocation.toString().contains("subProject/build/jacoco/test.exe"));
+            assertThat(fileSystemLocations).noneMatch(fileSystemLocation -> fileSystemLocation.toString().contains("intermediateProject/build/jacoco/test.exe"));
+        });
+    }
+
+    @Test
+    @DisplayName("Should configure execution data for sub project")
+    void shouldConfigureExecutionDataForSubProject() {
+        rootProject.getTasks().withType(CodeCoverageReportTask.class, task -> {
+            var fileSystemLocations = task.getExecutionData().getElements().get();
+            assertThat(fileSystemLocations).anyMatch(fileSystemLocation -> fileSystemLocation.toString().contains("intermediateProject/subProject/build/jacoco/test.exe"));
         });
     }
 


### PR DESCRIPTION
This commit modifies the CodeCoverageReportTask to no longer add source sets or execution data for projects which have no actual source directory. This to account for projects which use intermediate sub projects as an organisational method. These projects often have no source directories and would cause the task to fail.